### PR TITLE
FIX: Makefile and README.md conda envs issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 conda_all:
 	conda env create -f=./conda_envs/sklearndev0/environment.yml
 	conda env create -f=./conda_envs/sklearndev1/environment.yml
+	conda env create -f=./conda_envs/sklearndev2/environment.yml
 	conda env create -f=./conda_envs/sklearnprod0/environment.yml
 
 conda_dev0:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To **activate** the conda environments simply use conda as usual i.e. `source ac
 
 `sklearndev1` : Same as `sklearndev0` but includes pandas and jupyter notebook for additional interactive testing
 
-`sklearndev1` : Same as `sklearndev2` but includes pandas and jupyter notebook and `feather` for additional interactive testing
+`sklearndev2` : Same as `sklearndev1` but includes pandas and jupyter notebook and `feather` for additional interactive testing
 
 `sklearnprod0`: This contains the latest conda **production** `scikit-learn` build and is useful for current production testing of `sklearn`
 


### PR DESCRIPTION
FIX:
1, The previous conda command conda_all does not include sklearndev2
2, README has a typo of sklearndev2.